### PR TITLE
Add codes to solve UnsolvedSymbolException

### DIFF
--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -226,7 +226,9 @@ public class SpeciminRunner {
   /**
    * Given a directory, this method will delete that directory and recursively delete the parent
    * directories until it meets a non-empty directory. Be careful when making any changes to this
-   * method. This method is used to delete the temporary directory created by UnsolvedSymbolVisitor.
+   * method, as an incorrect conditional statement could result in the deletion of non-empty
+   * directories. This method is used to delete the temporary directory created by
+   * UnsolvedSymbolVisitor.
    *
    * @param fileDir the directory of the file to be deleted
    */

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -17,9 +17,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
@@ -69,6 +71,31 @@ public class SpeciminRunner {
       parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
     }
 
+    UnsolvedSymbolVisitor addMissingClass = new UnsolvedSymbolVisitor(root);
+    /**
+     * The set of path of files that have been created by addMissingClass. We will delete all those
+     * files in the end.
+     */
+    Set<Path> createdClass = new HashSet<>();
+    while (addMissingClass.gettingException()) {
+      addMissingClass.setExceptionToFalse();
+      for (CompilationUnit cu : parsedTargetFiles.values()) {
+        addMissingClass.setImportStatement(cu.getImports());
+        cu.accept(addMissingClass, null);
+      }
+      addMissingClass.updateSyntheticSourceCode();
+      createdClass.addAll(addMissingClass.getCreatedClass());
+      // since the root directory is updated, we need to update the SymbolSolver
+      TypeSolver newTypeSolver =
+          new CombinedTypeSolver(
+              new ReflectionTypeSolver(), new JavaParserTypeSolver(new File(root)));
+      JavaSymbolSolver newSymbolSolver = new JavaSymbolSolver(newTypeSolver);
+      StaticJavaParser.getConfiguration().setSymbolResolver(newSymbolSolver);
+      parsedTargetFiles = new HashMap<>();
+      for (String targetFile : targetFiles) {
+        parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
+      }
+    }
     List<String> targetMethodNames = options.valuesOf(targetMethodsOption);
 
     // Use a two-phase approach: the first phase finds the target(s) and records
@@ -88,6 +115,11 @@ public class SpeciminRunner {
               + String.join(", ", unfoundMethods));
     }
 
+    // add all files related to the targeted methods to the parsedTargetFile
+    for (String classFullName : finder.getUsedClass()) {
+      String directoryOfFile = classFullName.replace(".", "/") + ".java";
+      parsedTargetFiles.put(directoryOfFile, parseJavaFile(root, directoryOfFile));
+    }
     MethodPrunerVisitor methodPruner =
         new MethodPrunerVisitor(finder.getTargetMethods(), finder.getUsedMethods());
 
@@ -124,6 +156,8 @@ public class SpeciminRunner {
         System.out.println("with error: " + e);
       }
     }
+    // delete all the temporary files created by UnsolvedSymbolVisitor
+    deleteFiles(createdClass);
   }
 
   /**
@@ -163,5 +197,49 @@ public class SpeciminRunner {
    */
   private static CompilationUnit parseJavaFile(String root, String path) throws IOException {
     return StaticJavaParser.parse(Path.of(root, path));
+  }
+
+  /**
+   * This method delete all files from a set of Paths. If a file is the only file in its parent
+   * directory, this method will recursively delete the parent directories until it meets a
+   * non-empty directory.
+   *
+   * @param fileList the set of Paths of files to be deleted
+   */
+  private static void deleteFiles(Set<Path> fileList) {
+    for (Path filePath : fileList) {
+      try {
+        Files.delete(filePath);
+        File parentDir = filePath.toFile().getParentFile();
+        if (parentDir != null && parentDir.exists() && parentDir.isDirectory()) {
+          String[] fileContained = parentDir.list();
+          if (fileContained != null && fileContained.length == 0) {
+            // Recursive call to delete the parent directory
+            deleteFileFamily(parentDir);
+          }
+        }
+      } catch (Exception e) {
+      }
+    }
+  }
+
+  /**
+   * Given a directory, this method will delete that directory and recursively delete the parent
+   * directories until it meets a non-empty directory. Be careful when making any changes to this
+   * method. This method is used to delete the temporary directory created by UnsolvedSymbolVisitor.
+   *
+   * @param fileDir the directory of the file to be deleted
+   */
+  private static void deleteFileFamily(File fileDir) {
+    fileDir.delete();
+    File parentDir = fileDir.getParentFile();
+    if (parentDir != null && parentDir.exists() && parentDir.isDirectory()) {
+      String[] fileContained = parentDir.list();
+      // Be cautious when making any changes to this line, you might actually delete important
+      // directories in the project.
+      if (fileContained != null && fileContained.length == 0) {
+        deleteFileFamily(parentDir);
+      }
+    }
   }
 }

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -117,10 +117,10 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
     } else {
       if (!this.classFQName.equals("")) {
         throw new UnsupportedOperationException(
-                "Attempted to enter an unexpected kind of class: "
-                        + decl.getFullyQualifiedName()
-                        + " but already had a set classFQName: "
-                        + classFQName);
+            "Attempted to enter an unexpected kind of class: "
+                + decl.getFullyQualifiedName()
+                + " but already had a set classFQName: "
+                + classFQName);
       }
       // Should always be present.
       this.classFQName = decl.getFullyQualifiedName().orElseThrow();
@@ -140,7 +140,7 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
     // The substring here is to remove the method's return type. Return types cannot contain spaces.
     // TODO: test this with annotations
     String methodName =
-            this.classFQName + "#" + methodDeclAsString.substring(methodDeclAsString.indexOf(' ') + 1);
+        this.classFQName + "#" + methodDeclAsString.substring(methodDeclAsString.indexOf(' ') + 1);
     if (this.targetMethodNames.contains(methodName)) {
       insideTargetMethod = true;
       targetMethods.add(method.resolve().getQualifiedSignature());

--- a/src/main/java/org/checkerframework/specimin/UnsolvedClass.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClass.java
@@ -9,16 +9,16 @@ import java.util.Set;
  */
 public class UnsolvedClass {
   /** Set of methods belongs to the class */
-  public Set<UnsolvedMethod> methods;
+  private final Set<UnsolvedMethod> methods;
 
   /** The name of the class */
-  public String className;
+  private final String className;
 
   /**
    * The name of the package of the class. We rely on the import statements from the source codes to
    * guess the package name.
    */
-  public String packageName;
+  private final String packageName;
 
   /**
    * Create an instance of UnsolvedClass
@@ -35,6 +35,14 @@ public class UnsolvedClass {
     // MethodPrunerVisitor will take care of it
     UnsolvedMethod constructorMethod = new UnsolvedMethod(className, "");
     methods.add(constructorMethod);
+  }
+
+  public Set<UnsolvedMethod> getMethods() {
+    return methods;
+  }
+
+  public String getClassName() {
+    return className;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/UnsolvedClass.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClass.java
@@ -1,0 +1,65 @@
+package org.checkerframework.specimin;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * An UnsolvedClass instance is a representation of a class that can not be solved by SymbolSolver.
+ * The reason is that the class file is not in the root directory.
+ */
+public class UnsolvedClass {
+  /** Set of methods belongs to the class */
+  public Set<UnsolvedMethod> methods;
+
+  /** The name of the class */
+  public String className;
+
+  /**
+   * The name of the package of the class. We rely on the import statements from the source codes to
+   * guess the package name.
+   */
+  public String packageName;
+
+  /**
+   * Create an instance of UnsolvedClass
+   *
+   * @param className the name of the class
+   * @param packageName the name of the package
+   */
+  public UnsolvedClass(String className, String packageName) {
+    this.className = className;
+    this.methods = new HashSet<>();
+    this.packageName = packageName;
+    // It is simpler to just add the method here than to figure out that it is needed and add it
+    // later during the visitor's phase. And if it turns out that the method is not used,
+    // MethodPrunerVisitor will take care of it
+    UnsolvedMethod constructorMethod = new UnsolvedMethod(className, "");
+    methods.add(constructorMethod);
+  }
+
+  /**
+   * Add a method to the class
+   *
+   * @param method the method to be added
+   */
+  public void addMethod(UnsolvedMethod method) {
+    this.methods.add(method);
+  }
+
+  /**
+   * Return the content of the class as a compilable Java file.
+   *
+   * @return the content of the class
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("package ").append(packageName).append(";\n");
+    sb.append("class ").append(className).append(" {\n");
+    for (UnsolvedMethod method : methods) {
+      sb.append(method.toString());
+    }
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
@@ -6,13 +6,13 @@ package org.checkerframework.specimin;
  */
 public class UnsolvedMethod {
   /** The name of the method */
-  public String name;
+  private final String name;
 
   /**
    * The return type of the method. At the moment, we set the return type the same as the class
    * where the method belongs to.
    */
-  public String returnType;
+  private final String returnType;
 
   /**
    * Create an instance of UnsolvedMethod

--- a/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
@@ -1,5 +1,8 @@
 package org.checkerframework.specimin;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * An UnsolvedMethod instance is a representation of a method that can not be solved by
  * SymbolSolver. The reason is that the class file of that method is not in the root directory.
@@ -15,6 +18,12 @@ public class UnsolvedMethod {
   private final String returnType;
 
   /**
+   * The list of parameters of the method. (Right now we won't touch it until the new variant of
+   * SymbolSolver is available)
+   */
+  private List<String> parameterList;
+
+  /**
    * Create an instance of UnsolvedMethod
    *
    * @param name the name of the method
@@ -23,8 +32,12 @@ public class UnsolvedMethod {
   public UnsolvedMethod(String name, String returnType) {
     this.name = name;
     this.returnType = returnType;
+    this.parameterList = new ArrayList<>();
   }
 
+  public List<String> getParameterList() {
+    return parameterList;
+  }
   /**
    * Return the content of the method. Note that the body of the method is stubbed out.
    *

--- a/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
@@ -1,0 +1,36 @@
+package org.checkerframework.specimin;
+
+/**
+ * An UnsolvedMethod instance is a representation of a method that can not be solved by
+ * SymbolSolver. The reason is that the class file of that method is not in the root directory.
+ */
+public class UnsolvedMethod {
+  /** The name of the method */
+  public String name;
+
+  /**
+   * The return type of the method. At the moment, we set the return type the same as the class
+   * where the method belongs to.
+   */
+  public String returnType;
+
+  /**
+   * Create an instance of UnsolvedMethod
+   *
+   * @param name the name of the method
+   * @param returnType the return type of the method
+   */
+  public UnsolvedMethod(String name, String returnType) {
+    this.name = name;
+    this.returnType = returnType;
+  }
+
+  /**
+   * Return the content of the method. Note that the body of the method is stubbed out.
+   *
+   * @return the content of the method with the body stubbed out
+   */
+  public String toString() {
+    return "\n    public " + returnType + " " + name + "() {\n        throw new Error();\n    }\n";
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -102,7 +102,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       if (importParts.length > 0) {
         String className = importParts[importParts.length - 1];
         String packageName = importStatement.replace("." + className, "");
-        if (className.equals("")) {
+        if (className.equals("*")) {
           if (!chosenPackage.equals("")) {
             throw new RuntimeException(
                 "Multiple wildcard import statements found. Please use explicit import"

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -146,11 +146,11 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     } catch (UnsolvedSymbolException e) {
       UnsolvedClass missedClass = getTheMissingClass(e);
       // NULL means that our exception-messages-based method is not good enough to find them
-      if (!missedClass.className.equals("NULL")) {
+      if (!missedClass.getClassName().equals("NULL")) {
         String methodName = method.getNameAsString();
         // for now, we will have the return type of a missing method the same as the class that
         // method belongs to
-        UnsolvedMethod missedMethod = new UnsolvedMethod(methodName, missedClass.className);
+        UnsolvedMethod missedMethod = new UnsolvedMethod(methodName, missedClass.getClassName());
         missedClass.addMethod(missedMethod);
         this.updateMissingClass(missedClass);
       }
@@ -203,8 +203,8 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     Iterator<UnsolvedClass> iterator = missingClass.iterator();
     while (iterator.hasNext()) {
       UnsolvedClass e = iterator.next();
-      if (e.className.equals(missedClass.className)) {
-        for (UnsolvedMethod method : missedClass.methods) {
+      if (e.getClassName().equals(missedClass.getClassName())) {
+        for (UnsolvedMethod method : missedClass.getMethods()) {
           e.addMethod(method);
         }
         return;
@@ -257,8 +257,10 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    * @param missedClass a synthetic class to be deleted
    */
   public void deleteOldSyntheticClass(UnsolvedClass missedClass) {
-    String classPackage = classAndImportMap.getOrDefault(missedClass.className, this.chosenPackage);
-    String filePathStr = this.rootDirectory + classPackage + "/" + missedClass.className + ".java";
+    String classPackage =
+        classAndImportMap.getOrDefault(missedClass.getClassName(), this.chosenPackage);
+    String filePathStr =
+        this.rootDirectory + classPackage + "/" + missedClass.getClassName() + ".java";
     Path filePath = Path.of(filePathStr);
     try {
       Files.delete(filePath);
@@ -277,10 +279,11 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   public void createMissingClass(UnsolvedClass missedClass) {
     StringBuilder fileContent = new StringBuilder();
     fileContent.append(missedClass);
-    String classPackage = classAndImportMap.getOrDefault(missedClass.className, this.chosenPackage);
+    String classPackage =
+        classAndImportMap.getOrDefault(missedClass.getClassName(), this.chosenPackage);
     String classDirectory = classPackage.replace(".", "/");
     String filePathStr =
-        this.rootDirectory + classDirectory + "/" + missedClass.className + ".java";
+        this.rootDirectory + classDirectory + "/" + missedClass.getClassName() + ".java";
     Path filePath = Paths.get(filePathStr);
     createdClass.add(filePath);
     try {

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -238,13 +238,10 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   }
 
   /**
-   * <<<<<<< HEAD The method to update the synthetic files. After each run, we might have new
-   * synthetic files to be created, or new methods to be added to existing synthetic classes. This
-   * method will delete all the synthetic files from the previous run and re-create those files with
-   * the input from the ======= The method to update synthetic files. After each run, we might have
-   * new synthetic files to be created, or new methods to be added to existing synthetic classes.
-   * This method will delete all the synthetic files from the previous run and re-create those files
-   * with the input from the >>>>>>> 0c756ed9f0907a60a3c895cb01159451a5bd90e9 current run.
+   * The method to update synthetic files. After each run, we might have new synthetic files to be
+   * created, or new methods to be added to existing synthetic classes. This method will delete all
+   * the synthetic files from the previous run and re-create those files with the input from the
+   * current run.
    */
   public void updateSyntheticSourceCode() {
     for (UnsolvedClass missedClass : missingClass) {

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1,0 +1,303 @@
+package org.checkerframework.specimin;
+
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.visitor.ModifierVisitor;
+import com.github.javaparser.ast.visitor.Visitable;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The visitor for the preliminary phase of Specimin. This visitor goes through the input files,
+ * spots out all the methods belonging to classes not in the source codes, and creates synthetic
+ * versions of those classes and methods. This preliminary step helps to prevent
+ * UnsolvedSymbolException errors for the next phases.
+ */
+public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
+
+  /** List of classes not in the source codes */
+  private List<UnsolvedClass> missingClass;
+
+  /** The same as the root being used in SpeciminRunner */
+  private String rootDirectory;
+
+  /**
+   * This is to check if the current synthetic files are enough to prevent UnsolvedSymbolException
+   * or we still need more.
+   */
+  private boolean gotException;
+
+  /**
+   * The list of classes that have been created. We use this list to delete all the temporary
+   * synthetic classes when Specimin finishes its run
+   */
+  private Set<Path> createdClass;
+
+  /** List of import statement from the current compilation unit that is being visited */
+  private List<String> importStatement;
+
+  /**
+   * This map the classes in the compilation unit with the related import statements in that unit
+   */
+  private Map<String, String> classAndImportMap;
+
+  /**
+   * If there is any import statement that ends with *, this string will be replaced by one of the
+   * class from those import statements.
+   */
+  private String chosenPackage = "To.Be.Replaced";
+
+  /**
+   * Create a new UnsolvedSymbolVisitor instance
+   *
+   * @param rootDirectory the root directory of the input files
+   */
+  public UnsolvedSymbolVisitor(String rootDirectory) {
+    this.rootDirectory = rootDirectory;
+    this.missingClass = new ArrayList<>();
+    this.gotException = true;
+    this.importStatement = new ArrayList<>();
+    this.classAndImportMap = new HashMap<>();
+    this.createdClass = new HashSet<>();
+  }
+
+  /**
+   * Set importStatement equals to the list of import statements from the current compilation unit.
+   * Also update the classAndImportMap based on this new list.
+   *
+   * @param listOfImports NodeList of import statements from the compilation unit
+   */
+  public void setImportStatement(NodeList<ImportDeclaration> listOfImports) {
+    List<String> currentImportList = new ArrayList<>();
+    for (ImportDeclaration importStatement : listOfImports) {
+      String importAsString = importStatement.getNameAsString();
+      currentImportList.add(importAsString);
+    }
+    this.importStatement = currentImportList;
+    this.setClassAndImportMap();
+  }
+
+  /**
+   * This method sets the classAndImportMap. This method is called in the method setImportStatement,
+   * as classAndImportMap and importStatements should always be in sync.
+   */
+  private void setClassAndImportMap() {
+    for (String importStatement : this.importStatement) {
+      String[] importParts = importStatement.split("\\.");
+      if (importParts.length > 0) {
+        String className = importParts[importParts.length - 1];
+        String packageName = importStatement.replace("." + className, "");
+        if (className.equals("*")) {
+          chosenPackage = packageName;
+        } else {
+          this.classAndImportMap.put(className, packageName);
+        }
+      }
+    }
+  }
+
+  /**
+   * Get the value of gotException
+   *
+   * @return gotException the value of gotException
+   */
+  public boolean gettingException() {
+    return gotException;
+  }
+
+  /**
+   * Get the classes that have been created by the current iteration of the visitor.
+   *
+   * @return createdClass the Set of Path of classes that have beenc created
+   */
+  public Set<Path> getCreatedClass() {
+    return createdClass;
+  }
+
+  /**
+   * Set gotException to false. This method is to be used at the beginning of each iteration of the
+   * visitor.
+   */
+  public void setExceptionToFalse() {
+    gotException = false;
+  }
+
+  @Override
+  public Visitable visit(MethodCallExpr method, Void p) {
+    String testString = method.getNameAsString();
+    try {
+      // this line is merely to check if there is UnsolvedSymbolException
+      testString = method.resolve().getClassName();
+    } catch (UnsolvedSymbolException e) {
+      UnsolvedClass missedClass = getTheMissingClass(e);
+      // NULL means that our exception-messages-based method is not good enough to find them
+      if (!missedClass.className.equals("NULL")) {
+        String methodName = method.getNameAsString();
+        // for now, we will have the return type of a missing method the same as the class that
+        // method belongs to
+        UnsolvedMethod missedMethod = new UnsolvedMethod(methodName, missedClass.className);
+        missedClass.addMethod(missedMethod);
+        this.updateMissingClass(missedClass);
+      }
+    }
+    // there are more elegant ways to update gotException, but the compiler will throw an error if
+    // the try block doesn't have any use
+    this.gotException = testString.equals(method.getNameAsString());
+    return super.visit(method, p);
+  }
+
+  @Override
+  public Visitable visit(Parameter parameter, Void p) {
+    String type = parameter.getNameAsString();
+    try {
+      type = parameter.resolve().toString();
+    } catch (UnsolvedSymbolException e) {
+      String className = parameter.getNameAsString();
+      UnsolvedClass newClass =
+          new UnsolvedClass(
+              className, classAndImportMap.getOrDefault(className, this.chosenPackage));
+      missingClass.add(newClass);
+    }
+    // there are more elegant ways to update gotException, but the compiler will throw an error if
+    // the try block doesn't have any use
+    gotException = type.equals(parameter.getNameAsString());
+    return super.visit(parameter, p);
+  }
+
+  @Override
+  public Visitable visit(ObjectCreationExpr newExpr, Void p) {
+    String type = newExpr.getTypeAsString();
+    try {
+      type = newExpr.resolve().getQualifiedName();
+    } catch (UnsolvedSymbolException e) {
+      UnsolvedClass newClass =
+          new UnsolvedClass(type, classAndImportMap.getOrDefault(type, this.chosenPackage));
+      this.updateMissingClass(newClass);
+    }
+    this.gotException = type.equals(newExpr.getTypeAsString());
+    return super.visit(newExpr, p);
+  }
+
+  /**
+   * This method is to update the missingClass list. The reason we have this update is to add a
+   * method to an existing class.
+   *
+   * @param missedClass the class to be updated
+   */
+  public void updateMissingClass(UnsolvedClass missedClass) {
+    Iterator<UnsolvedClass> iterator = missingClass.iterator();
+    while (iterator.hasNext()) {
+      UnsolvedClass e = iterator.next();
+      if (e.className.equals(missedClass.className)) {
+        for (UnsolvedMethod method : missedClass.methods) {
+          e.addMethod(method);
+        }
+        return;
+      }
+    }
+    missingClass.add(missedClass);
+  }
+
+  /**
+   * Based on the exception thrown by JavaParser, this method figure out which class file is missing
+   * in the source codes. This method is temporary and will be replaced by a proper SymbolSolver in
+   * the future.
+   *
+   * @param exceptionMessage the exception to be analyzed
+   * @return an instance of UnsolvedClass correlating to the exception messgae
+   */
+  public UnsolvedClass getTheMissingClass(UnsolvedSymbolException exceptionMessage) {
+    // a null cause means that the exception could not tell us which class file is missing
+    if (exceptionMessage.getCause() == null) {
+      return new UnsolvedClass("NULL", "NULL");
+    }
+    Throwable cause = exceptionMessage.getCause();
+    // This is a bit hard-coding since the Throwable instance of UnsolvedSymbolException has
+    // everything in the form of a message
+    if (cause != null && cause.getMessage() != null) {
+      String className = cause.getMessage().replace("Unsolved symbol : ", "");
+      return new UnsolvedClass(
+          className, this.classAndImportMap.getOrDefault(className, this.chosenPackage));
+    }
+    return new UnsolvedClass("NULL", "NULL");
+  }
+
+  /**
+   * <<<<<<< HEAD The method to update the synthetic files. After each run, we might have new
+   * synthetic files to be created, or new methods to be added to existing synthetic classes. This
+   * method will delete all the synthetic files from the previous run and re-create those files with
+   * the input from the ======= The method to update synthetic files. After each run, we might have
+   * new synthetic files to be created, or new methods to be added to existing synthetic classes.
+   * This method will delete all the synthetic files from the previous run and re-create those files
+   * with the input from the >>>>>>> 0c756ed9f0907a60a3c895cb01159451a5bd90e9 current run.
+   */
+  public void updateSyntheticSourceCode() {
+    for (UnsolvedClass missedClass : missingClass) {
+      this.deleteOldSyntheticClass(missedClass);
+      this.createMissingClass(missedClass);
+    }
+  }
+
+  /**
+   * This method is to delete a synthetic class. If that synthetic class is not created yet, the
+   * method will do nothing.
+   *
+   * @param missedClass a synthetic class to be deleted
+   */
+  public void deleteOldSyntheticClass(UnsolvedClass missedClass) {
+    String classPackage = classAndImportMap.getOrDefault(missedClass.className, this.chosenPackage);
+    String filePathStr = this.rootDirectory + classPackage + "/" + missedClass.className + ".java";
+    Path filePath = Path.of(filePathStr);
+    try {
+      Files.delete(filePath);
+    } catch (IOException e) {
+      // It means that the class that has not been created in the previous run of this visitor
+    }
+  }
+
+  /**
+   * This method create a synthetic file for a class that is not in the source codes. The class will
+   * be created in the root directory of the input. All these synthetic files will be deleted when
+   * Specimin finishes its run. (TO DO: What if Specimin doesn't have the write permission?)
+   *
+   * @param missedClass the class to be added
+   */
+  public void createMissingClass(UnsolvedClass missedClass) {
+    StringBuilder fileContent = new StringBuilder();
+    fileContent.append(missedClass);
+    String classPackage = classAndImportMap.getOrDefault(missedClass.className, this.chosenPackage);
+    String classDirectory = classPackage.replace(".", "/");
+    String filePathStr =
+        this.rootDirectory + classDirectory + "/" + missedClass.className + ".java";
+    Path filePath = Paths.get(filePathStr);
+    createdClass.add(filePath);
+    try {
+      Path parentPath = filePath.getParent();
+      if (parentPath != null && !Files.exists(parentPath)) {
+        Files.createDirectories(parentPath);
+      }
+      try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath.toFile()))) {
+        writer.write(fileContent.toString());
+      } catch (Exception e) {
+        throw new Error(e.getMessage());
+      }
+    } catch (IOException e) {
+      System.out.println("Error creating Java file: " + e.getMessage());
+    }
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 /**
  * The visitor for the preliminary phase of Specimin. This visitor goes through the input files,
- * spots out all the methods belonging to classes not in the source codes, and creates synthetic
+ * notices all the methods belonging to classes not in the source codes, and creates synthetic
  * versions of those classes and methods. This preliminary step helps to prevent
  * UnsolvedSymbolException errors for the next phases.
  */
@@ -272,7 +272,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   /**
    * This method create a synthetic file for a class that is not in the source codes. The class will
    * be created in the root directory of the input. All these synthetic files will be deleted when
-   * Specimin finishes its run. 
+   * Specimin finishes its run.
    *
    * @param missedClass the class to be added
    */

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -272,7 +272,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   /**
    * This method create a synthetic file for a class that is not in the source codes. The class will
    * be created in the root directory of the input. All these synthetic files will be deleted when
-   * Specimin finishes its run. (TO DO: What if Specimin doesn't have the write permission?)
+   * Specimin finishes its run. 
    *
    * @param missedClass the class to be added
    */

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -31,7 +31,7 @@ import java.util.Set;
 public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
 
   /** List of classes not in the source codes */
-  private List<UnsolvedClass> missingClass;
+  private Set<UnsolvedClass> missingClass;
 
   /** The same as the root being used in SpeciminRunner */
   private String rootDirectory;
@@ -69,7 +69,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    */
   public UnsolvedSymbolVisitor(String rootDirectory) {
     this.rootDirectory = rootDirectory;
-    this.missingClass = new ArrayList<>();
+    this.missingClass = new HashSet<>();
     this.gotException = true;
     this.importStatement = new ArrayList<>();
     this.classAndImportMap = new HashMap<>();

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -60,7 +60,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    * If there is any import statement that ends with *, this string will be replaced by one of the
    * class from those import statements.
    */
-  private String chosenPackage = "To.Be.Replaced";
+  private String chosenPackage = "";
 
   /**
    * Create a new UnsolvedSymbolVisitor instance
@@ -102,7 +102,12 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       if (importParts.length > 0) {
         String className = importParts[importParts.length - 1];
         String packageName = importStatement.replace("." + className, "");
-        if (className.equals("*")) {
+        if (className.equals("")) {
+          if (!chosenPackage.equals("")) {
+            throw new RuntimeException(
+                "Multiple wildcard import statements found. Please use explicit import"
+                    + " statements.");
+          }
           chosenPackage = packageName;
         } else {
           this.classAndImportMap.put(className, packageName);


### PR DESCRIPTION
Professor,

This is my attempt to solve our problems with the `UnsolvedSymbolException`.

As we discussed, there are mainly two steps we need to do to prevent `UnsolvedSymbolException`:
1. Figure out the class where the unsolved method belongs to
2. Repeatedly update the synthetic files until there is no UnsolvedSymbolException left

Even though this PR has both steps, I kindly request you to review only the second step, which involves excluding the method `getTheMissingClass` in `UnsolvedSymbolVisitor`.

Right now, we are relying on exception thrown by JavaParser to figure out the class of the unsolved method. But this only works for simple cases like `method.getType()`, `message.toString()`,... This version of `UnsolvedSymbolVisitor` is not able to solve cases like `method.getType().isVoidType()` as `UnsolvedSymbolException` will not tell us the missing class for those cases.

I think my next task in this project is to write a variant of `SymbolSolver` to replace the method `getTheMissingClass` in `UnsolvedSymbolVisitor`, but I think it would be nice if we can refine my codes for the second step first. I think it would reduce the workload for both of us compared to performing code reviews for both steps at once. 

