### PR TITLE
Add dedicated return type

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
+++ b/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
@@ -1,0 +1,100 @@
+package org.checkerframework.specimin;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+class JavaTypeCorrect {
+
+  /** List of the files to correct the types */
+  public Set<String> fileNameList;
+
+  /**
+   * The root directory of the files in the fileNameList. If there are more than one root
+   * directories involved, consider using more than one instances of JavaTypeCorrect
+   */
+  public String sourcePath;
+
+  /**
+   * This map is for type correcting. The key is the name of the current incorrect type, and the
+   * value is the name of the desired correct type.
+   */
+  private Map<String, String> typeToChange;
+
+  /**
+   * Create a new JavaTypeCorrect instance. The directories of files in fileNameList are relative to
+   * SpeciminRunner
+   *
+   * @param rootDirectory the root directory of the files to correct types
+   * @param fileNameList the list of the relative directory of the files to correct types
+   */
+  public JavaTypeCorrect(String rootDirectory, Set<String> fileNameList) {
+    this.fileNameList = fileNameList;
+    this.sourcePath = rootDirectory;
+    this.typeToChange = new HashMap<>();
+  }
+
+  public Map<String, String> getTypeToChange() {
+    return typeToChange;
+  }
+
+  /**
+   * This method updates typeToChange by using javac to run all the files in fileNameList and
+   * analyzing the error messages returned by javac
+   */
+  public void correctTypesForAllFiles() {
+    for (String fileName : fileNameList) {
+      runJavacAndUpdateTypes(fileName);
+    }
+  }
+
+  /**
+   * This method uses javac to run a file and updates typeToChange if that file has any incompatible
+   * type error
+   *
+   * @param filePath the directory of the file to be analyzed
+   */
+  public void runJavacAndUpdateTypes(String filePath) {
+    try {
+      String command = "javac";
+      File file = new File(filePath);
+      String[] arguments = {command, "-sourcepath", sourcePath, file.getAbsolutePath()};
+      ProcessBuilder processBuilder = new ProcessBuilder(arguments);
+      processBuilder.redirectErrorStream(true);
+      Process process = processBuilder.start();
+      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.contains("error: incompatible types")) {
+          updateTypeToChange(line);
+        }
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * This method updates typeToChange by relying on the error messages from javac
+   *
+   * @param errorMessage the error message to be analyzed
+   */
+  private void updateTypeToChange(String errorMessage) {
+    String[] splitErrorMessage = errorMessage.split("\\s+");
+    if (splitErrorMessage.length < 7) {
+      throw new RuntimeException("Unexpected type error messages: " + errorMessage);
+    }
+    /* There are two possible forms of error messages here:
+     * 1. error: incompatible types: <type1> cannot be converted to <type2>
+     * 2. error: incompatible types: found <type1> required <type2>
+     */
+    if (errorMessage.contains("cannot be converted to")) {
+      typeToChange.put(splitErrorMessage[4], splitErrorMessage[splitErrorMessage.length - 1]);
+    } else {
+      typeToChange.put(splitErrorMessage[5], splitErrorMessage[splitErrorMessage.length - 1]);
+    }
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -120,20 +120,7 @@ public class SpeciminRunner {
       String directoryOfFile = classFullName.replace(".", "/") + ".java";
       parsedTargetFiles.put(directoryOfFile, parseJavaFile(root, directoryOfFile));
     }
-    Set<String> returnTypeOfUnsolvedMethod = addMissingClass.getReturnTypeList();
 
-    // for unsolved methods used by the target method, we need to include the class of their return
-    // types
-    for (String methodName : finder.getSimplifiedUsedMethods()) {
-      String capitalizedMethodName =
-          methodName.substring(0, 1).toUpperCase() + methodName.substring(1);
-      if (returnTypeOfUnsolvedMethod.contains(capitalizedMethodName + "ReturnType")) {
-        String directoryOfFile =
-            "org/checkerframework/specimin/" + capitalizedMethodName + "ReturnType" + ".java";
-        parsedTargetFiles.put(directoryOfFile, parseJavaFile(root, directoryOfFile));
-        System.out.println(directoryOfFile);
-      }
-    }
     MethodPrunerVisitor methodPruner =
         new MethodPrunerVisitor(finder.getTargetMethods(), finder.getUsedMethods());
 
@@ -147,10 +134,11 @@ public class SpeciminRunner {
     String outputDirectory = options.valueOf(outputDirectoryOption);
 
     for (Entry<String, CompilationUnit> target : parsedTargetFiles.entrySet()) {
-      // If a compilation output's entire body has been removed and it is not the return type for an
-      // unsolved method, do not output it.
-      if (isEmptyCompilationUnit(target.getValue())
-          && !target.getKey().contains("org/checkerframework/specimin")) {
+      // If a compilation output's entire body has been removed (TO DO: After combining
+      // TargetMethodFinderVisitor and UnsolvedSymbolVisitor, if a compilation unit is the return
+      // type for an
+      // unsolved method, do output it even if it is empty)
+      if (isEmptyCompilationUnit(target.getValue())) {
         continue;
       }
 

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -120,6 +120,20 @@ public class SpeciminRunner {
       String directoryOfFile = classFullName.replace(".", "/") + ".java";
       parsedTargetFiles.put(directoryOfFile, parseJavaFile(root, directoryOfFile));
     }
+    Set<String> returnTypeOfUnsolvedMethod = addMissingClass.getReturnTypeList();
+
+    // for unsolved methods used by the target method, we need to include the class of their return
+    // types
+    for (String methodName : finder.getSimplifiedUsedMethods()) {
+      String capitalizedMethodName =
+          methodName.substring(0, 1).toUpperCase() + methodName.substring(1);
+      if (returnTypeOfUnsolvedMethod.contains(capitalizedMethodName + "ReturnType")) {
+        String directoryOfFile =
+            "org/checkerframework/specimin/" + capitalizedMethodName + "ReturnType" + ".java";
+        parsedTargetFiles.put(directoryOfFile, parseJavaFile(root, directoryOfFile));
+        System.out.println(directoryOfFile);
+      }
+    }
     MethodPrunerVisitor methodPruner =
         new MethodPrunerVisitor(finder.getTargetMethods(), finder.getUsedMethods());
 
@@ -133,8 +147,10 @@ public class SpeciminRunner {
     String outputDirectory = options.valueOf(outputDirectoryOption);
 
     for (Entry<String, CompilationUnit> target : parsedTargetFiles.entrySet()) {
-      // If a compilation output's entire body has been removed, do not output it.
-      if (isEmptyCompilationUnit(target.getValue())) {
+      // If a compilation output's entire body has been removed and it is not the return type for an
+      // unsolved method, do not output it.
+      if (isEmptyCompilationUnit(target.getValue())
+          && !target.getKey().contains("org/checkerframework/specimin")) {
         continue;
       }
 

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -149,6 +149,10 @@ public class SpeciminRunner {
     String outputDirectory = options.valueOf(outputDirectoryOption);
 
     for (Entry<String, CompilationUnit> target : parsedTargetFiles.entrySet()) {
+      // If a compilation output's entire body has been removed, do not output it.
+      if (isEmptyCompilationUnit(target.getValue())) {
+        continue;
+      }
 
       Path targetOutputPath = Path.of(outputDirectory, target.getKey());
       // Create any parts of the directory structure that don't already exist.

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -38,7 +38,6 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
    */
   private final Set<String> usedMethods = new HashSet<>();
 
-  private final Set<String> simplifiedUsedMethods = new HashSet<>();
   /**
    * Classes of the methods that were actually used by the targets. These classes will be included
    * in the input.
@@ -89,10 +88,6 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
    */
   public Set<String> getUsedMethods() {
     return usedMethods;
-  }
-
-  public Set<String> getSimplifiedUsedMethods() {
-    return simplifiedUsedMethods;
   }
   ;
 
@@ -161,7 +156,6 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   public Visitable visit(MethodCallExpr call, Void p) {
     if (insideTargetMethod) {
       usedMethods.add(call.resolve().getQualifiedSignature());
-      simplifiedUsedMethods.add(call.getNameAsString());
       usedClass.add(call.resolve().getPackageName() + "." + call.resolve().getClassName());
     }
     return super.visit(call, p);
@@ -171,7 +165,6 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   public Visitable visit(ObjectCreationExpr newExpr, Void p) {
     if (insideTargetMethod) {
       usedMethods.add(newExpr.resolve().getQualifiedSignature());
-      simplifiedUsedMethods.add(newExpr.getTypeAsString());
       usedClass.add(newExpr.resolve().getPackageName() + "." + newExpr.resolve().getClassName());
     }
     return super.visit(newExpr, p);

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -6,10 +6,7 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * The main visitor for Specimin's first phase, which locates the target method(s) and compiles
@@ -38,6 +35,7 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
    */
   private final Set<String> usedMethods = new HashSet<>();
 
+  private final Set<String> simplifiedUsedMethods = new HashSet<>();
   /**
    * Classes of the methods that were actually used by the targets. These classes will be included
    * in the input.
@@ -89,6 +87,11 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   public Set<String> getUsedMethods() {
     return usedMethods;
   }
+
+  public Set<String> getSimplifiedUsedMethods() {
+    return simplifiedUsedMethods;
+  }
+  ;
 
   /**
    * Get the classes of the methods that the target method uses. The Strings in the set are the
@@ -155,6 +158,7 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   public Visitable visit(MethodCallExpr call, Void p) {
     if (insideTargetMethod) {
       usedMethods.add(call.resolve().getQualifiedSignature());
+      simplifiedUsedMethods.add(call.getNameAsString());
       usedClass.add(call.resolve().getPackageName() + "." + call.resolve().getClassName());
     }
     return super.visit(call, p);
@@ -164,6 +168,7 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   public Visitable visit(ObjectCreationExpr newExpr, Void p) {
     if (insideTargetMethod) {
       usedMethods.add(newExpr.resolve().getQualifiedSignature());
+      simplifiedUsedMethods.add(newExpr.getTypeAsString());
       usedClass.add(newExpr.resolve().getPackageName() + "." + newExpr.resolve().getClassName());
     }
     return super.visit(newExpr, p);

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -89,7 +89,6 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   public Set<String> getUsedMethods() {
     return usedMethods;
   }
-  ;
 
   /**
    * Get the classes of the methods that the target method uses. The Strings in the set are the

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -6,7 +6,10 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * The main visitor for Specimin's first phase, which locates the target method(s) and compiles

--- a/src/main/java/org/checkerframework/specimin/UnsolvedClass.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClass.java
@@ -45,6 +45,9 @@ public class UnsolvedClass {
     return className;
   }
 
+  public String getPackageName() {
+    return packageName;
+  }
   /**
    * Add a method to the class
    *

--- a/src/main/java/org/checkerframework/specimin/UnsolvedClass.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClass.java
@@ -58,6 +58,21 @@ public class UnsolvedClass {
   }
 
   /**
+   * Update the return type of a method. Note: this method is supposed to be used to update
+   * synthetic methods, where the return type of each method is distinct.
+   *
+   * @param currentReturnType
+   * @param desiredReturnType
+   */
+  public void updateMethodByReturnType(String currentReturnType, String desiredReturnType) {
+    for (UnsolvedMethod method : methods) {
+      if (method.getReturnType().equals(currentReturnType)) {
+        method.setReturnType(desiredReturnType);
+      }
+    }
+  }
+
+  /**
    * Return the content of the class as a compilable Java file.
    *
    * @return the content of the class
@@ -66,7 +81,7 @@ public class UnsolvedClass {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("package ").append(packageName).append(";\n");
-    sb.append("class ").append(className).append(" {\n");
+    sb.append("public class ").append(className).append(" {\n");
     for (UnsolvedMethod method : methods) {
       sb.append(method.toString());
     }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
@@ -15,7 +15,7 @@ public class UnsolvedMethod {
    * The return type of the method. At the moment, we set the return type the same as the class
    * where the method belongs to.
    */
-  private final String returnType;
+  private String returnType;
 
   /**
    * The list of parameters of the method. (Right now we won't touch it until the new variant of
@@ -33,6 +33,10 @@ public class UnsolvedMethod {
     this.name = name;
     this.returnType = returnType;
     this.parameterList = new ArrayList<>();
+  }
+
+  public void setReturnType(String returnType) {
+    this.returnType = returnType;
   }
 
   public String getReturnType() {

--- a/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
@@ -35,8 +35,8 @@ public class UnsolvedMethod {
     this.parameterList = new ArrayList<>();
   }
 
-  public List<String> getParameterList() {
-    return parameterList;
+  public String getReturnType() {
+    return returnType;
   }
   /**
    * Return the content of the method. Note that the body of the method is stubbed out.

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -55,7 +55,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   private List<String> importStatement;
 
   /**
-   * This map the classes in the compilation unit with the related import statements in that unit
+   * This map the classes in the compilation unit with the related package
    */
   private Map<String, String> classAndPackageMap;
 
@@ -216,6 +216,14 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     }
   }
 
+  /**
+   * Given a MethodCallExpr instance, this method will return the synthetic class for the method
+   * involved. Thus, make sure that the input method actually belongs to an existing synthetic class
+   * before calling this method.
+   *
+   * @param method the method call to be analyzed
+   * @return the name of the synthetic class of that method
+   */
   public static String getSyntheticClass(MethodCallExpr method) {
     String fullNameOfTheClass = method.getScope().get().calculateResolvedType().describe();
     String shortNameOfTheClass =

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -41,7 +41,6 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   /** This instance maps the name of a synthetic method with its synthetic class */
   Map<String, UnsolvedClass> syntheticMethodAndClass;
 
-  private Set<String> classToBeReturnType;
   /**
    * This is to check if the current synthetic files are enough to prevent UnsolvedSymbolException
    * or we still need more.
@@ -78,7 +77,6 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     this.importStatement = new ArrayList<>();
     this.classAndPackageMap = new HashMap<>();
     this.createdClass = new HashSet<>();
-    this.classToBeReturnType = new HashSet<>();
     this.syntheticMethodAndClass = new HashMap<>();
   }
 
@@ -168,7 +166,6 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
           returnTypeForThisMethod.getClassName(), returnTypeForThisMethod.getPackageName());
       this.updateMissingClass(missingClass);
       this.updateMissingClass(returnTypeForThisMethod);
-      classToBeReturnType.add(returnTypeForThisMethod.getClassName());
       syntheticMethodAndClass.put(methodSimpleName, missingClass);
     }
 

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -15,7 +15,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * The visitor for the preliminary phase of Specimin. This visitor goes through the input files,

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -36,6 +36,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   /** The same as the root being used in SpeciminRunner */
   private String rootDirectory;
 
+  /** List of classes temporarily created to be the return types of unsolved methods */
+  private Set<String> returnTypeList;
+
   /**
    * This is to check if the current synthetic files are enough to prevent UnsolvedSymbolException
    * or we still need more.
@@ -74,6 +77,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     this.importStatement = new ArrayList<>();
     this.classAndImportMap = new HashMap<>();
     this.createdClass = new HashSet<>();
+    this.returnTypeList = new HashSet<>();
   }
 
   /**
@@ -134,6 +138,10 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     return createdClass;
   }
 
+  public Set<String> getReturnTypeList() {
+    return returnTypeList;
+  }
+
   /**
    * Set gotException to false. This method is to be used at the beginning of each iteration of the
    * visitor.
@@ -153,11 +161,17 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       // NULL means that our exception-messages-based method is not good enough to find them
       if (!missedClass.getClassName().equals("NULL")) {
         String methodName = method.getNameAsString();
-        // for now, we will have the return type of a missing method the same as the class that
-        // method belongs to
-        UnsolvedMethod missedMethod = new UnsolvedMethod(methodName, missedClass.getClassName());
+        String capitalizedMethodName =
+            methodName.substring(0, 1).toUpperCase() + methodName.substring(1);
+        UnsolvedClass returnTypeForThisMethod =
+            new UnsolvedClass(
+                capitalizedMethodName + "ReturnType", "org.checkerframework.specimin");
+        UnsolvedMethod missedMethod =
+            new UnsolvedMethod(methodName, returnTypeForThisMethod.getClassName());
         missedClass.addMethod(missedMethod);
+        this.updateMissingClass(returnTypeForThisMethod);
         this.updateMissingClass(missedClass);
+        returnTypeList.add(returnTypeForThisMethod.getClassName());
       }
     }
     // there are more elegant ways to update gotException, but the compiler will throw an error if
@@ -284,8 +298,15 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   public void createMissingClass(UnsolvedClass missedClass) {
     StringBuilder fileContent = new StringBuilder();
     fileContent.append(missedClass);
-    String classPackage =
-        classAndImportMap.getOrDefault(missedClass.getClassName(), this.chosenPackage);
+    String className = missedClass.getClassName();
+    String classPackage = "";
+    if (classAndImportMap.containsKey(className)) {
+      classPackage = classAndImportMap.get(className);
+    } else if (returnTypeList.contains(className)) {
+      classPackage = "org.checkerframework.specimin";
+    } else {
+      classPackage = this.chosenPackage;
+    }
     String classDirectory = classPackage.replace(".", "/");
     String filePathStr =
         this.rootDirectory + classDirectory + "/" + missedClass.getClassName() + ".java";


### PR DESCRIPTION
Professor @kelloggm, this is my new codes for `Specimin`. Apart from having dedicated return type for each unsolved method, this new codes also have a new approach to analyze `MethodCallExpr` instances. We won't rely on the messages of the `UnsolvedSymbolException` anymore. (we still rely on `UnsolvedSymbolException`, we just don't rely on the message content of the exception)

This new approach is similar to induction. For a method call such as this one: `Object.method1().method2()....methodN()`, `methodN()` will only be analyzed and has synthetic file created if all the synthetic files related to `methodN-1()` are ready and compilable. Thus, when we actually analyze `methodN()`, it is easy to know which synthetic class it belongs to. So for the example above, in the first run, `UnsolvedSymbolVisitor` will create the synthetic file for `Object` if needed. Then in the second run, `UnsolvedSymbolVisitor` will create the synthetic file for `method1()`, and so on.

The number of times that `UnsolvedSymbolVisitor` will loop is equal to the number of elements in the longest method call in the input. I think this approach will run fast enough for developers to feel comfortable when using Specimin. In the future, we can improve the performance by combining this visitor with `TargetMethodFinderVisitor`. Also, for each run,  `UnsolvedSymbolVisitor` will delete all the old synthetic files and re-write everything all over again. We can improve the performance by having `UnsolvedSymbolVisitor` only delete and re-write synthetic files that are actually updated during that run.

Please take a look and let me know your opinion. Thank you