### PR TITLE
Add initializing methods of fields to used members

### DIFF
--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -3,6 +3,7 @@ package org.checkerframework.specimin;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.VariableDeclarator;
@@ -22,8 +23,10 @@ import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -76,6 +79,12 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
    * usually indicates an error.
    */
   private final List<String> unfoundMethods;
+
+  /**
+   * Maintains a mapping between fields initialized by method calls, associating each field name
+   * with the corresponding method call.
+   */
+  private final Map<String, MethodCallExpr> initializedFieldsAndMethods = new HashMap<>();
 
   /**
    * Create a new target method finding visitor.
@@ -152,6 +161,20 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
       this.classFQName = "";
     }
     return result;
+  }
+
+  @Override
+  public Visitable visit(FieldDeclaration field, Void p) {
+    for (VariableDeclarator var : field.getVariables()) {
+      Optional<Expression> possibleInitializer = var.getInitializer();
+      if (possibleInitializer.isPresent()) {
+        Expression initializer = possibleInitializer.get();
+        if (initializer.isMethodCallExpr()) {
+          initializedFieldsAndMethods.put(var.getName().asString(), initializer.asMethodCallExpr());
+        }
+      }
+    }
+    return super.visit(field, p);
   }
 
   @Override
@@ -265,6 +288,12 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   public Visitable visit(FieldAccessExpr expr, Void p) {
     if (insideTargetMethod) {
       usedMembers.add(classFQName + "#" + expr.getName().asString());
+      if (initializedFieldsAndMethods.containsKey(expr.getNameAsString())) {
+        MethodCallExpr initCall = initializedFieldsAndMethods.get(expr.getNameAsString());
+        usedMembers.add(initCall.resolve().getQualifiedSignature());
+        usedClass.add(
+            initCall.resolve().getPackageName() + "." + initCall.resolve().getClassName());
+      }
     }
     Expression caller = expr.getScope();
     if (caller instanceof SuperExpr) {
@@ -282,6 +311,13 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
       ResolvedValueDeclaration exprDecl = expr.resolve();
       if (exprDecl instanceof ResolvedFieldDeclaration) {
         usedClass.add(exprDecl.asField().declaringType().getQualifiedName());
+
+        if (initializedFieldsAndMethods.containsKey(expr.getNameAsString())) {
+          MethodCallExpr initCall = initializedFieldsAndMethods.get(expr.getNameAsString());
+          usedMembers.add(initCall.resolve().getQualifiedSignature());
+          usedClass.add(
+              initCall.resolve().getPackageName() + "." + initCall.resolve().getClassName());
+        }
       }
     }
     return super.visit(expr, p);

--- a/src/test/java/org/checkerframework/specimin/FieldInitializedByMethodCall.java
+++ b/src/test/java/org/checkerframework/specimin/FieldInitializedByMethodCall.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * If a field is used by a target method and that field is initialized by another method, the method
+ * that initialize the field should also be included in the final output.
+ */
+public class FieldInitializedByMethodCall {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "fieldInitializedByMethodCall",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/fieldInitializedByMethodCall/expected/com/example/Simple.java
+++ b/src/test/resources/fieldInitializedByMethodCall/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.mypackage.C;
+
+class Simple {
+
+    final int b = C.get();
+
+    int bar() {
+        return b++;
+    }
+}

--- a/src/test/resources/fieldInitializedByMethodCall/expected/com/mypackage/C.java
+++ b/src/test/resources/fieldInitializedByMethodCall/expected/com/mypackage/C.java
@@ -1,0 +1,8 @@
+package com.mypackage;
+
+public class C {
+
+    public static int get() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/fieldInitializedByMethodCall/input/com/example/Simple.java
+++ b/src/test/resources/fieldInitializedByMethodCall/input/com/example/Simple.java
@@ -1,0 +1,15 @@
+package com.example;
+
+import com.example.MyClass;
+import unreal.pack.AClass;
+
+class Simple {
+    // Target method.
+    void bar() {
+        int x  = 5;
+        String y = "hello";
+        AClass z = new AClass();
+        MyClass.process(x);
+        org.testing.ThisClass.process(y, z);
+    }
+}

--- a/src/test/resources/fieldInitializedByMethodCall/input/com/example/Simple.java
+++ b/src/test/resources/fieldInitializedByMethodCall/input/com/example/Simple.java
@@ -1,15 +1,10 @@
 package com.example;
 
-import com.example.MyClass;
-import unreal.pack.AClass;
+import com.mypackage.C;
 
 class Simple {
-    // Target method.
-    void bar() {
-        int x  = 5;
-        String y = "hello";
-        AClass z = new AClass();
-        MyClass.process(x);
-        org.testing.ThisClass.process(y, z);
+    final int b = C.get();
+    int bar() {
+        return b++;
     }
 }


### PR DESCRIPTION
Professor,

This is the PR to fix the issue with fields that initialized by a method call.

There is a map called `syntheticMethodAndClass` that were used to update types based on the error messages of javac. I have changed it to `syntheticMethodReturnTypeAndClass`, so that I don't have to figure out the name of the method based on the type complaining of javac.

Please take a look. Thank you.