### PR TITLE
Failing test

### DIFF
--- a/src/test/java/org/checkerframework/specimin/TypeVarCollisionTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarCollisionTest.java
@@ -1,0 +1,13 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test checks if Specimin can work for methods that have type parameters themselves. */
+public class TypeVarCollisionTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevar-collision", new String[] {"org/Foo.java"}, new String[] {"org.Foo#useT(T)"});
+  }
+}

--- a/src/test/resources/typevar-collision/expected/org/Foo.java
+++ b/src/test/resources/typevar-collision/expected/org/Foo.java
@@ -1,0 +1,7 @@
+package org;
+
+public class Foo<T> {
+    T useT(T t) {
+        return t;
+    }
+}

--- a/src/test/resources/typevar-collision/input/com/T.java
+++ b/src/test/resources/typevar-collision/input/com/T.java
@@ -1,0 +1,3 @@
+package com;
+
+public class T {}

--- a/src/test/resources/typevar-collision/input/org/Foo.java
+++ b/src/test/resources/typevar-collision/input/org/Foo.java
@@ -1,0 +1,10 @@
+package org;
+
+// This import isn't used.
+import com.T;
+
+public class Foo<T> {
+    T useT(T t) {
+        return t;
+    }
+}


### PR DESCRIPTION
Based on our discussion earlier of type variable's that might shadow the name of an imported class. This test ought to pass, but it looks like an import statement isn't being removed. I'm guessing that is related to one of our other open bugs/PRs (#51?), so we can wait to merge this into #46 until we fix that.